### PR TITLE
Fix adding of extra trailing slash when calling getUrlWithCreds()

### DIFF
--- a/src/com/tw/go/plugin/util/HttpRepoURL.java
+++ b/src/com/tw/go/plugin/util/HttpRepoURL.java
@@ -91,7 +91,7 @@ public class HttpRepoURL extends RepoUrl {
                 sb.append("?").append(urlObj.getQuery());
             if(urlObj.getRef() != null)
                 sb.append("#").append(urlObj.getRef());
-            if(urlObj.getQuery() == null && urlObj.getRef() == null && !urlObj.getPath().endsWith("/"))
+            if(urlObj.getQuery() == null && urlObj.getRef() == null && urlObj.getPath().isEmpty())
                 sb.append("/");
             return sb.toString();
         } catch (Exception e) {

--- a/test/fast/com/tw/go/plugin/util/RepoUrlTest.java
+++ b/test/fast/com/tw/go/plugin/util/RepoUrlTest.java
@@ -84,7 +84,7 @@ public class RepoUrlTest {
     public void shouldReturnUrlAsIsIfNoCredentialsProvided() throws Exception {
         String url = "http://repohost/some/path";
         HttpRepoURL repoUrl = (HttpRepoURL) RepoUrl.create(url, null, null);
-        assertThat(repoUrl.getUrlWithBasicAuth(), is(url+"/"));
+        assertThat(repoUrl.getUrlWithBasicAuth(), is(url));
     }
     @Test
     public void shouldHandleQuery() throws Exception {


### PR DESCRIPTION
Currently when the method is called with an url line http://www.example.com/path/to/file.zip this method puts an extra trailing slash at the end and you end up with the url - http://user:pass@www.example.com/path/to/file.zip/
Although the url has creeds inserted, the trailing slash makes it invalid and any requests to it cause 404 responses.
